### PR TITLE
clean argv[] to let the output of "ps aux|grep xd" be '-u ***** -p *****...

### DIFF
--- a/xd_h3c.c
+++ b/xd_h3c.c
@@ -103,6 +103,8 @@ int main(int argc,char *argv[])
 				{
 					username = (char*)malloc(100);
 					strcpy(username, argv[optind]);
+					//clean argv[]
+					strcpy(argv[optind], "*****");
 					getPassword();
 					getDevice();
 				}
@@ -110,6 +112,8 @@ int main(int argc,char *argv[])
 				{
 					username = (char *)malloc(100);
 					strcpy(username, argv[optind]);
+					//clean argv[]
+					strcpy(argv[optind], "*****");
 				}
 			}
 			break;
@@ -135,13 +139,17 @@ int main(int argc,char *argv[])
 			{
 				password=(char *)malloc(100);
 				strcpy(password,argv[optind]);
+				//clean argv[]
+				strcpy(argv[optind], "*");
 				getDevice();
 			}
 			else
 			{
 				password = (char *)malloc(100);
 				strcpy(password,argv[optind]);
-			}
+				//clean argv[]
+				strcpy(argv[optind], "*****");
+		}
 			break;
 			//网卡名称 
 			case 'n':


### PR DESCRIPTION
clean argv[] to let the output of "ps aux|grep xd" be '-u ****\* -p *****' instead of the right username or password.
