### PR TITLE
kill existing dhclient for runDHCP

### DIFF
--- a/authenticate.c
+++ b/authenticate.c
@@ -16,6 +16,7 @@ void RunDHCP(const char *DeviceName)
 	char cmd[32];
 	fprintf(stdout, "------开始运行DHCP服务获取IP------\n");
 	//TODO: detect the existing dhclient and exit them
+	system("killall -q -g dhclient");//ooo added
 	strcpy(cmd, "sudo dhclient ");
 	strcat(cmd, DeviceName);
 	strcat(cmd, " &");

--- a/xd_h3c.c
+++ b/xd_h3c.c
@@ -203,7 +203,7 @@ int main(int argc,char *argv[])
        
 	if((strlen(username)!=0)&&(strlen(password)!=0)&&(strlen(devicename)!=0))
 	{
-		//printf("%s %s %s\n",username,password,devicename);
+	//	printf("%s %s %s\n",username,password,devicename);
 		Authentication(username,password,devicename);
 	}
 	else


### PR DESCRIPTION
sometimes a dhclient is already running warning message display on the screen of server, and then network link is lost. may this would help solving this issue.
