### PR TITLE
移除libpcap依赖

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 CC=gcc
 BIN=xdh3c
-LIBS= -lpcap -lm
 CFLAGS=-Wall
 INSTALL=install
 RM=rm
@@ -17,7 +16,7 @@ md5.o: ./md5/md5.c
 	$(CC) $(CFLAGS) -c $<
 
 $(BIN): xd_h3c.o authenticate.o md5.o
-	$(CC) $(CFLAGS) $+ $(LIBS) -o $@
+	$(CC) $(CFLAGS) $+ -o $@
 
 install:
 	$(INSTALL) -d /usr/local/bin

--- a/authenticate.h
+++ b/authenticate.h
@@ -4,15 +4,15 @@
 #include <assert.h>
 #include <time.h>
 
-#include <pcap.h>
-
 #include <unistd.h>
 #include <signal.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <net/if.h>
 #include <arpa/inet.h>
+#include <linux/if_packet.h>
 
+#define ETH_P_PAE 0x888e
 /* 802.1X报文结构 */
 typedef enum {REQUEST=1, RESPONSE=2, SUCCESS=3, FAILURE=4, H3CDATA=10} EAP_Code;
 typedef enum {IDENTITY=1, NOTIFICATION=2, MD5=4, AVAILIABLE=20} EAP_Type;
@@ -22,23 +22,23 @@ typedef uint8_t EAP_ID;
 int Authentication(char *UserName, char *Password, char *DeviceName);
 
 /* 发送EAP-START开始认证包 */
-void SendStartPkt(pcap_t *adhandle, const uint8_t MAC[6]);
+void SendStartPkt(int fd, const uint8_t MAC[6]);
 
 /* 回应Identity类型的请求，返回IP和用户名 */
-void ResponseIdentity(pcap_t *adhandle, const uint8_t* request,
+void ResponseIdentity(int fd, const uint8_t* request,
                                         const uint8_t ethhdr[14],
                                         const uint8_t ip[4],
                                         const char* username);
 /* 回应MD5类型的请求，返回加密后的密码，用户名 */
-void ResponseMD5(pcap_t *adhandle, const uint8_t* request,
+void ResponseMD5(int fd, const uint8_t* request,
                                    const uint8_t ethhdr[14],
                                    const char* username,
                                    const char* passwd);
 /* 回应Notitfication类型的请求，返回客户端版本和操作系统版本 */
-void ResponseNotification(pcap_t *handle, const uint8_t* request,
+void ResponseNotification(int fd, const uint8_t* request,
                                           const uint8_t ethhdr[14]);
 /* 保持在线，上传客户端版本号及本地IP地址 */
-void ResponseAvailiable(pcap_t* handle, const uint8_t* request,
+void ResponseAvailiable(int fd, const uint8_t* request,
                                         const uint8_t ethhdr[14],
                                         const uint8_t ip[4],
                                         const char* username);


### PR DESCRIPTION
有同学在编译openwrt版本时因为不会链接libpcap而at我的h3clite项目，只有openwrt toolchain的情况下交叉编译需要链接的程序确实很不方便。
因为我的学校协议比较简单，h3clite项目若要适配标准的h3c协议代码改动太大，故尝试将该项目改为raw socket方式发包。
这边没有条件测试修改后的正确性和稳定性，希望原作者协助测试并考虑merge或开一个不依赖pcap的branch。
