### PR TITLE
设置终端属性时的出错处理

### DIFF
--- a/xd_h3c.c
+++ b/xd_h3c.c
@@ -292,7 +292,7 @@ int set_disp_mode(int fd, int option)
     else
         term.c_lflag &= ~ECHOFLAGS;
     err=tcsetattr(fd,TCSAFLUSH,&term);
-    if(err==-1 && err==EINTR) {
+    if(err==-1 && errno==EINTR) {
         perror("Cannot set the attribution of the terminal");
         return 1;
     }


### PR DESCRIPTION
EINTR在系统头文件中定义为4，err不可能同时为-1和４；errno为<errno.h>中定义的全局变量
